### PR TITLE
Fix MTA:SA detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@
 <!-- TABLE OF CONTENTS -->
 ## Table of Contents
 
-* [Installation](#installation)
-  * [Testing](#testing)
-  * [Installing](#installing)
-  * [Updating](#updating)
-* [Why?](#why)
-* [Adding server assets](#adding-server-assets)
-* [Troubleshooting](#troubleshooting)
-  * [Discord shows "Grand Theft Auto: San Andreas" as my current game](#discord-shows-grand-theft-auto-san-andreas-as-my-current-game)
-  * [Discord shows "MTA: San Andreas" as my current game](#discord-shows-mta-san-andreas-as-my-current-game)
-  * [Rich presence is not showing MTA anymore, even though I restarted MTA multiple times already](#rich-presence-is-not-showing-mta-anymore-even-though-i-restarted-mta-multiple-times-already)
-  * [The status gets set to "Idle" even though I'm still connected to the server](#the-status-gets-set-to-idle-even-though-im-still-connected-to-the-server)
-* [Contributing](#contributing)
-* [Known bugs](#known-bugs)
-* [License](#license)
+- [Table of Contents](#table-of-contents)
+- [Installation](#installation)
+  - [Testing](#testing)
+  - [Installing](#installing)
+  - [Updating](#updating)
+- [Why?](#why)
+- [Adding server assets](#adding-server-assets)
+- [Troubleshooting](#troubleshooting)
+  - [Discord shows "MTA: San Andreas" as my current game](#discord-shows-mta-san-andreas-as-my-current-game)
+  - [Rich presence is not showing MTA anymore, even though I restarted MTA multiple times already](#rich-presence-is-not-showing-mta-anymore-even-though-i-restarted-mta-multiple-times-already)
+  - [The status gets set to "Idle", even though I'm still connected to the server](#the-status-gets-set-to-idle-even-though-im-still-connected-to-the-server)
+- [Contributing](#contributing)
+- [Known bugs](#known-bugs)
+- [License](#license)
 
 
 
@@ -46,15 +46,14 @@
 ### Testing
 
 First make sure it works for you before you install it. **It's recommended to be on the latest Windows 10 Build (I haven't tested it on any other OS or earlier versions of Windows).**
-You will also need to play MTA:SA through its proxy application, so Discord doesn't pickup default GTA:SA as the current playing game.
-1. Make sure your MTA:SA uses proxy_sa.exe instead of gta_sa.exe. To check this, open your Task Manager and see which one of both applications is running while you have MTA:SA open. Click [here](#discord-shows-grand-theft-auto-san-andreas-as-my-current-game) to learn how to force this behaviour.
-2. Close your MTA:SA instance if you have it running.
-3. Download the newest release from the <a href="https://github.com/pkfln/mta-discord-rpc/releases">releases page</a> (mta-discord-rpc.exe).
-4. Open the folder containing the downloaded executable.
-5. Execute the file by double-clicking it.
-6. If you're not getting any errors, try to open MTA:SA.
-7. Check your Discord Rich Presence status and see, if it's setting your status.
-8. If everything works so far, you're ready to install it. If you do get some errors, try to fix them or open a new issue. Also don't forget to check the [Troubleshooting](#troubleshooting) section.
+
+1. Close your MTA:SA instance if you have it running.
+2. Download the newest release from the <a href="https://github.com/pkfln/mta-discord-rpc/releases">releases page</a> (mta-discord-rpc.exe).
+3. Open the folder containing the downloaded executable.
+4. Execute the file by double-clicking it.
+5. If you're not getting any errors, try to open MTA:SA.
+6. Check your Discord Rich Presence status and see, if it's setting your status.
+7. If everything works so far, you're ready to install it. If you do get some errors, try to fix them or open a new issue. Also don't forget to check the [Troubleshooting](#troubleshooting) section.
 
 ### Installing
 
@@ -93,11 +92,6 @@ If you want your server logo to be shown on the rich presence instead of the def
 
 <!-- TROUBLESHOOTING -->
 ## Troubleshooting
-
-### Discord shows "Grand Theft Auto: San Andreas" as my current game
-
-You must force MTA:SA to use their proxy application. The easiest method probably is installing an ASI loader: <a href="https://www.gtagarage.com/mods/show.php?id=21709">Download Silent's ASI Loader here</a> and add & replace these files to your GTA:SA directory.
-
 
 ### Discord shows "MTA: San Andreas" as my current game
 

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -45,7 +45,7 @@ export default abstract class Game {
 
   static watchMTASA(): void {
     setInterval(async () => {
-      const mtaProcess = (await tasklist()).find(x => x.imageName === 'proxy_sa.exe');
+      const mtaProcess = (await tasklist()).find(x => x.imageName === 'Multi Theft Auto.exe');
       if (!mtaProcess && this.gameState !== EGameState.CLOSED) {
         log.debug('MTA was closed, resetting state');
         return this.resetState();


### PR DESCRIPTION
Starting from version **1.5.9-release-21570**, MTA:SA stopped using `proxy_sa.exe`, which caused this project to stop working. 

This PR fix the detection process by replacing `proxy_sa.exe` with `Multi Theft Auto.exe`, which detects if MTA:SA is running correctly.